### PR TITLE
Github Actions update

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,60 +45,13 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           COSIGN_SECRET: ${{ secrets.COSIGN_SECRET }}
           REPOSITORY_OWNER: ${{ env.REPOSITORY_OWNER }}
           REPOSITORY_NAME: ${{ env.REPOSITORY_NAME }}
+          HOMEBREW_TAP: ${{ env.HOMEBREW_TAP }}
 
-      - uses: robinraju/release-downloader@v1.10
-        id: download_release_amd64
-        with:
-          repository: "${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME }}"   # "adorigi/kaytu"
-          fileName: '*'
-          latest: true
-          tarBall: true
-          zipBall: true
-
-      - name: update cli version in homebrew
-        run: |
-          sed -i "s+VERSION_HOMEBREW+$(echo "${{ github.ref_name }}" | sed 's/^.//')+g" homebrew/kaytu.rb
-          
-          ls 
-          export VERSION=${{ github.ref_name }}
-          export VERSION=${VERSION#v}
-          echo "version=$VERSION"
-          echo "kaytu_$VERSION_darwin_amd64"
-
-          sha256sum "kaytu_${VERSION}_darwin_amd64.tar.gz" | awk '{print $1}' > newHash
-          sed -i "s+HASH_MAC_AMD64+$(cat newHash)+g" homebrew/kaytu.rb
-          
-          sha256sum "kaytu_${VERSION}_darwin_arm64.tar.gz" | awk '{print $1}' > newHash
-          sed -i "s+HASH_MAC_ARM64+$(cat newHash)+g" homebrew/kaytu.rb
-          
-          sha256sum "kaytu_${VERSION}_linux_arm64.tar.gz" | awk '{print $1}' > newHash
-          sed -i "s+HASH_LINUX_ARM64+$(cat newHash)+g" homebrew/kaytu.rb
-          
-          sha256sum "kaytu_${VERSION}_linux_amd64.tar.gz" | awk '{print $1}' > newHash
-          sed -i "s+HASH_LINUX_AMD64+$(cat newHash)+g" homebrew/kaytu.rb
-          
-          git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
-          
-          cd ${{ env.HOMEBREW_TAP }}
-          
-          git remote add ${{ env.HOMEBREW_TAP }}-origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
-          git config user.name 'adorigi'
-          git config user.email 'gulegulzaradnan@gmail.com'
-          
-          cp ../homebrew/kaytu.rb kaytu.rb  
-          
-          git checkout main
-          git add .
-          git commit -a -m "update cli version"
-          git push ${{ env.HOMEBREW_TAP }}-origin 
-          
-          cd ..
-          rm -rf ${{ env.HOMEBREW_TAP }}
 #   sign-windows:
 #     runs-on: ubuntu-latest
 #     needs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,6 +48,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           COSIGN_SECRET: ${{ secrets.COSIGN_SECRET }}
+          REPOSITORY_OWNER: ${{ env.REPOSITORY_OWNER }}
+          REPOSITORY_NAME: ${{ env.REPOSITORY_NAME }}
 
       - uses: robinraju/release-downloader@v1.10
         id: download_release_amd64

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,9 +78,11 @@ jobs:
           echo "version=$VERSION"
           echo "kaytu_$VERSION_darwin_amd64"
 
-          sudo apt update -y && sudo apt -y install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
-          sudo apt-get update -y
-          sudo apt-get -y install osslsigncode
+          sudo apt-get -qq update -y 
+          sudo apt-get -qq -y install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
+
+          sudo apt-get -qq  update -y
+          sudo apt-get -qq  -y install osslsigncode
           echo "${{ secrets.SELFSIGNED_KEY }}" | base64 --decode > cert.key
           echo "${{ secrets.SELFSIGNED_CRT }}" | base64 --decode > cert.crt          
           osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe -out kaytu.exe

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,6 +73,8 @@ jobs:
       - name: Add windows zip
         id: add_windows_zip
         run: |
+          ls -l 
+
           export VERSION=${{ github.ref_name }}
           export VERSION=${VERSION#v}
           echo "version=$VERSION"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,21 +82,21 @@ jobs:
           
           git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
           
-          cd homebrew-cli-tap
+          cd ${{ env.HOMEBREW_TAP }}
           
-          git remote add homebrew-cli-tap-origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
-          git config user.name 'Kaytu Developer'
-          git config user.email 'dev@kaytu.io'
+          git remote add ${{ env.HOMEBREW_TAP }}-origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
+          git config user.name 'adorigi'
+          git config user.email 'gulegulzaradnan@gmail.com'
           
           cp ../homebrew/kaytu.rb kaytu.rb  
           
           git checkout main
           git add .
           git commit -a -m "update cli version"
-          git push homebrew-cli-tap-origin 
+          git push ${{ env.HOMEBREW_TAP }}-origin 
           
           cd ..
-          rm -rf homebrew-cli-tap
+          rm -rf ${{ env.HOMEBREW_TAP }}
 #   sign-windows:
 #     runs-on: ubuntu-latest
 #     needs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,7 +67,7 @@ jobs:
       - uses: robinraju/release-downloader@v1.10
         id: download_release_amd64
         with:
-          repository: "kaytu-io/kaytu"
+          repository: "${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}"
           fileName: '*'
           latest: true
       - name: Add windows zip
@@ -98,45 +98,45 @@ jobs:
             d
           }' kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
           
-          export UPLOAD_URL=$(curl --silent "https://api.github.com/repos/kaytu-io/kaytu/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}"  | jq -r .upload_url)
+          export UPLOAD_URL=$(curl --silent "https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}"  | jq -r .upload_url)
           echo "$UPLOAD_URL"
           echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
 
           release_id=$(curl --request GET \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/latest \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}' | jq '.id')
           echo $release_id
           assets=$(curl --request GET \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/$release_id/assets \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/$release_id/assets \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}')
           echo $assets
           amd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$amd64 \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$amd64 \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
           linuxarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_arm64") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxarm64 \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$linuxarm64 \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
           linuxamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_amd64") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxamd64 \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$linuxamd64 \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
           darwinarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_arm64") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinarm64 \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$darwinarm64 \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
           darwinamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_amd64") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinamd64 \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$darwinamd64 \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
           windowszip=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowszip \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$windowszip \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
           windowschecksum=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt") | .id')
           curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowschecksum \
+            --url https://api.github.com/repos/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME}}/releases/assets/$windowschecksum \
             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
 
       - name: Upload Release Asset amd64 zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:        
       - 'v[0-9]+.[0-9]+.[0-9]+'  
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc'
   workflow_dispatch:
     inputs:
       publishChocolatey:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,125 +52,129 @@ jobs:
           REPOSITORY_NAME: ${{ env.REPOSITORY_NAME }}
           HOMEBREW_TAP: ${{ env.HOMEBREW_TAP }}
 
-#   sign-windows:
-#     runs-on: ubuntu-latest
-#     needs:
-#       - release
-#     steps:
-#       - name: Download new tag
-#         uses: actions/download-artifact@v2
-#         with:
-#           name: new_tag
-#       - name: Set new tag
-#         id: set_new_tag
-#         run: |
-#           echo "::set-output name=new_tag::$(cat new_tag.txt)"
-#       - uses: robinraju/release-downloader@v1.10
-#         id: download_release_amd64
-#         with:
-#           repository: "kaytu-io/kaytu"
-#           fileName: '*'
-#           latest: true
-#       - name: Add windows zip
-#         id: add_windows_zip
-#         run: |
-#           sudo apt update -y && sudo apt -y install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
-#           sudo apt-get update -y
-#           sudo apt-get -y install osslsigncode
-#           echo "${{ secrets.SELFSIGNED_KEY }}" | base64 --decode > cert.key
-#           echo "${{ secrets.SELFSIGNED_CRT }}" | base64 --decode > cert.crt          
-#           osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe -out kaytu.exe
-#           mkdir kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
-#           mv kaytu.exe kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
-#           zip -r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
-#           sha256sum kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip > kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-          
-#           sed -i '/kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip/{
-#             r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-#             d
-#           }' kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
-          
-#           export UPLOAD_URL=$(curl --silent "https://api.github.com/repos/kaytu-io/kaytu/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}"  | jq -r .upload_url)
-#           echo "$UPLOAD_URL"
-#           echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+  sign-windows:
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    steps:
+      - name: Set new tag
+        id: set_new_tag
+        run: |
+            export VERSION=${{ github.ref_name }}
+            export VERSION=${VERSION#v}
+            echo "version=$VERSION"
+            echo "::set-output name=new_tag::$VERSION"
+      - uses: robinraju/release-downloader@v1.10
+        id: download_release_amd64
+        with:
+          repository: "kaytu-io/kaytu"
+          fileName: '*'
+          latest: true
+      - name: Add windows zip
+        id: add_windows_zip
+        run: |
+          export VERSION=${{ github.ref_name }}
+          export VERSION=${VERSION#v}
+          echo "version=$VERSION"
+          echo "kaytu_$VERSION_darwin_amd64"
 
-#           release_id=$(curl --request GET \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}' | jq '.id')
-#           echo $release_id
-#           assets=$(curl --request GET \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/$release_id/assets \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}')
-#           echo $assets
-#           amd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$amd64 \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-#           linuxarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_arm64") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxarm64 \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-#           linuxamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_amd64") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxamd64 \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-#           darwinarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_arm64") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinarm64 \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-#           darwinamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_amd64") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinamd64 \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-#           windowszip=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowszip \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-#           windowschecksum=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt") | .id')
-#           curl --request DELETE \
-#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowschecksum \
-#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          sudo apt update -y && sudo apt -y install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
+          sudo apt-get update -y
+          sudo apt-get -y install osslsigncode
+          echo "${{ secrets.SELFSIGNED_KEY }}" | base64 --decode > cert.key
+          echo "${{ secrets.SELFSIGNED_CRT }}" | base64 --decode > cert.crt          
+          osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_$VERSION_windows_amd64.exe -out kaytu.exe
+          mkdir kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
+          mv kaytu.exe kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
+          zip -r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
+          sha256sum kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip > kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+          
+          sed -i '/kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip/{
+            r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+            d
+          }' kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
+          
+          export UPLOAD_URL=$(curl --silent "https://api.github.com/repos/kaytu-io/kaytu/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}"  | jq -r .upload_url)
+          echo "$UPLOAD_URL"
+          echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
 
-#       - name: Upload Release Asset amd64 zip
-#         id: upload-release-asset-amd64-zip
-#         uses: actions/upload-release-asset@v1
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-#         with:
-#           upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
-#           asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
-#           asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
-#           asset_content_type: application/zip
-#       - name: Upload Release Asset amd64 zip checksum
-#         id: upload-release-asset-amd64-zip-checksum
-#         uses: actions/upload-release-asset@v1
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-#         with:
-#           upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
-#           asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-#           asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-#           asset_content_type: text/plain
-#       - name: Upload Release Asset new checksum
-#         id: upload-release-asset-new-checksum
-#         uses: actions/upload-release-asset@v1
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-#         with:
-#           upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
-#           asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
-#           asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
-#           asset_content_type: text/plain
-#   chocolatey-publish:
-#     name: Release Kaytu choco
-#     if: github.event.inputs.publishChocolatey == 'true'
-#     runs-on: windows-latest
-#     needs:
-#       - release
-#       - sign-windows
-#     steps:
-#       - uses: actions/checkout@v2
-#       - name: Generate & push
-#         run: scripts/build.ps1
-#         env:
-#           CHOCO_API_KEY: ${{ secrets.CHOCO_APIKEY }}
+          release_id=$(curl --request GET \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}' | jq '.id')
+          echo $release_id
+          assets=$(curl --request GET \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/$release_id/assets \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}')
+          echo $assets
+          amd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$amd64 \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          linuxarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_arm64") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxarm64 \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          linuxamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_amd64") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxamd64 \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          darwinarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_arm64") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinarm64 \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          darwinamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_amd64") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinamd64 \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          windowszip=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowszip \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+          windowschecksum=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt") | .id')
+          curl --request DELETE \
+            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowschecksum \
+            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+
+      - name: Upload Release Asset amd64 zip
+        id: upload-release-asset-amd64-zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
+          asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
+          asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
+          asset_content_type: application/zip
+      - name: Upload Release Asset amd64 zip checksum
+        id: upload-release-asset-amd64-zip-checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
+          asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+          asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+          asset_content_type: text/plain
+      - name: Upload Release Asset new checksum
+        id: upload-release-asset-new-checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
+          asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
+          asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
+          asset_content_type: text/plain
+  chocolatey-publish:
+    name: Release Kaytu choco
+    if: github.event.inputs.publishChocolatey == 'true'
+    runs-on: windows-latest
+    needs:
+      - release
+      - sign-windows
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate & push
+        run: scripts/build.ps1
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_APIKEY }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:        
+      - 'v[0-9]+.[0-9]+.[0-9]+'  
   workflow_dispatch:
     inputs:
       publishChocolatey:
@@ -29,25 +29,13 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: stable
-      - name: Tag version
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          release_branches: main
-          tag_prefix: v
       - name: Set latest tag output
         id: set_latest_tag
-        run: |
-          if [[ -z "${{ steps.tag_version.outputs.new_tag }}" ]]; then
-            echo "latest_tag=${{ steps.tag_version.outputs.previous_tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "latest_tag=${{ steps.tag_version.outputs.new_tag }}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "latest_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
       - name: Save new tag
         id: save_new_tag
         run: |
-          version=${{ steps.tag_version.outputs.new_tag }}
+          version=${{ github.ref_name }}
           version=${version#v}
           echo $version > new_tag.txt
       - name: Upload new tag

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,7 +83,7 @@ jobs:
           sudo apt-get -y install osslsigncode
           echo "${{ secrets.SELFSIGNED_KEY }}" | base64 --decode > cert.key
           echo "${{ secrets.SELFSIGNED_CRT }}" | base64 --decode > cert.crt          
-          osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_$VERSION_windows_amd64.exe -out kaytu.exe
+          osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe -out kaytu.exe
           mkdir kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
           mv kaytu.exe kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
           zip -r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,47 +15,22 @@ on:
           - "false"
         default: "false"
 
+env:
+    REPOSITORY_OWNER: "adorigi"
+    REPOSITORY_NAME: "kaytu"
+    HOMEBREW_TAP: "homebrew-adorigi"
+
 jobs:
-  tag:
-    runs-on: ubuntu-latest
-    outputs:
-      latest_tag: ${{ steps.set_latest_tag.outputs.latest_tag }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: stable
-      - name: Set latest tag output
-        id: set_latest_tag
-        run: echo "latest_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-      - name: Save new tag
-        id: save_new_tag
-        run: |
-          version=${{ github.ref_name }}
-          version=${version#v}
-          echo $version > new_tag.txt
-      - name: Upload new tag
-        uses: actions/upload-artifact@v2
-        with:
-          name: new_tag
-          path: new_tag.txt
   release:
     runs-on: ubuntu-latest
-    needs:
-      - tag
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: stable
       - name: Install cosign
@@ -70,15 +45,14 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           COSIGN_SECRET: ${{ secrets.COSIGN_SECRET }}
 
       - uses: robinraju/release-downloader@v1.10
         id: download_release_amd64
         with:
-          repository: "kaytu-io/kaytu"
+          repository: "${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME }}"   # "adorigi/kaytu"
           fileName: '*'
           latest: true
           tarBall: true
@@ -86,10 +60,10 @@ jobs:
 
       - name: update cli version in homebrew
         run: |
-          sed -i "s+VERSION_HOMEBREW+$(echo "${{ needs.tag.outputs.latest_tag }}" | sed 's/^.//')+g" homebrew/kaytu.rb
+          sed -i "s+VERSION_HOMEBREW+$(echo "${{ github.ref_name }}" | sed 's/^.//')+g" homebrew/kaytu.rb
           
           ls 
-          export VERSION=${{ needs.tag.outputs.latest_tag }}
+          export VERSION=${{ github.ref_name }}
           export VERSION=${VERSION#v}
           echo "version=$VERSION"
           echo "kaytu_$VERSION_darwin_amd64"
@@ -106,11 +80,11 @@ jobs:
           sha256sum "kaytu_${VERSION}_linux_amd64.tar.gz" | awk '{print $1}' > newHash
           sed -i "s+HASH_LINUX_AMD64+$(cat newHash)+g" homebrew/kaytu.rb
           
-          git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/kaytu-io/homebrew-cli-tap.git
+          git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
           
           cd homebrew-cli-tap
           
-          git remote add homebrew-cli-tap-origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/kaytu-io/homebrew-cli-tap.git
+          git remote add homebrew-cli-tap-origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}.git
           git config user.name 'Kaytu Developer'
           git config user.email 'dev@kaytu.io'
           
@@ -123,127 +97,125 @@ jobs:
           
           cd ..
           rm -rf homebrew-cli-tap
-  sign-windows:
-    runs-on: ubuntu-latest
-    needs:
-      - tag
-      - release
-    steps:
-      - name: Download new tag
-        uses: actions/download-artifact@v2
-        with:
-          name: new_tag
-      - name: Set new tag
-        id: set_new_tag
-        run: |
-          echo "::set-output name=new_tag::$(cat new_tag.txt)"
-      - uses: robinraju/release-downloader@v1.10
-        id: download_release_amd64
-        with:
-          repository: "kaytu-io/kaytu"
-          fileName: '*'
-          latest: true
-      - name: Add windows zip
-        id: add_windows_zip
-        run: |
-          sudo apt update -y && sudo apt -y install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
-          sudo apt-get update -y
-          sudo apt-get -y install osslsigncode
-          echo "${{ secrets.SELFSIGNED_KEY }}" | base64 --decode > cert.key
-          echo "${{ secrets.SELFSIGNED_CRT }}" | base64 --decode > cert.crt          
-          osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe -out kaytu.exe
-          mkdir kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
-          mv kaytu.exe kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
-          zip -r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
-          sha256sum kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip > kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+#   sign-windows:
+#     runs-on: ubuntu-latest
+#     needs:
+#       - release
+#     steps:
+#       - name: Download new tag
+#         uses: actions/download-artifact@v2
+#         with:
+#           name: new_tag
+#       - name: Set new tag
+#         id: set_new_tag
+#         run: |
+#           echo "::set-output name=new_tag::$(cat new_tag.txt)"
+#       - uses: robinraju/release-downloader@v1.10
+#         id: download_release_amd64
+#         with:
+#           repository: "kaytu-io/kaytu"
+#           fileName: '*'
+#           latest: true
+#       - name: Add windows zip
+#         id: add_windows_zip
+#         run: |
+#           sudo apt update -y && sudo apt -y install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
+#           sudo apt-get update -y
+#           sudo apt-get -y install osslsigncode
+#           echo "${{ secrets.SELFSIGNED_KEY }}" | base64 --decode > cert.key
+#           echo "${{ secrets.SELFSIGNED_CRT }}" | base64 --decode > cert.crt          
+#           osslsigncode sign -certs cert.crt -key cert.key -n "Kaytu" -i https://kaytu.io/ -in kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe -out kaytu.exe
+#           mkdir kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
+#           mv kaytu.exe kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
+#           zip -r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64
+#           sha256sum kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip > kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
           
-          sed -i '/kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip/{
-            r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-            d
-          }' kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
+#           sed -i '/kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip/{
+#             r kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+#             d
+#           }' kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
           
-          export UPLOAD_URL=$(curl --silent "https://api.github.com/repos/kaytu-io/kaytu/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}"  | jq -r .upload_url)
-          echo "$UPLOAD_URL"
-          echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+#           export UPLOAD_URL=$(curl --silent "https://api.github.com/repos/kaytu-io/kaytu/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}"  | jq -r .upload_url)
+#           echo "$UPLOAD_URL"
+#           echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
 
-          release_id=$(curl --request GET \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}' | jq '.id')
-          echo $release_id
-          assets=$(curl --request GET \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/$release_id/assets \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}')
-          echo $assets
-          amd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$amd64 \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-          linuxarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_arm64") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxarm64 \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-          linuxamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_amd64") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxamd64 \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-          darwinarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_arm64") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinarm64 \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-          darwinamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_amd64") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinamd64 \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-          windowszip=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowszip \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
-          windowschecksum=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt") | .id')
-          curl --request DELETE \
-            --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowschecksum \
-            --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           release_id=$(curl --request GET \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}' | jq '.id')
+#           echo $release_id
+#           assets=$(curl --request GET \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/$release_id/assets \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}')
+#           echo $assets
+#           amd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.exe") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$amd64 \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           linuxarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_arm64") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxarm64 \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           linuxamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_linux_amd64") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$linuxamd64 \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           darwinarm64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_arm64") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinarm64 \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           darwinamd64=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_darwin_amd64") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$darwinamd64 \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           windowszip=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowszip \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
+#           windowschecksum=$(echo $assets | jq '.[] | select(.name=="kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt") | .id')
+#           curl --request DELETE \
+#             --url https://api.github.com/repos/kaytu-io/kaytu/releases/assets/$windowschecksum \
+#             --header 'authorization: Bearer ${{ secrets.GH_TOKEN }}'
 
-      - name: Upload Release Asset amd64 zip
-        id: upload-release-asset-amd64-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
-          asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
-          asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
-          asset_content_type: application/zip
-      - name: Upload Release Asset amd64 zip checksum
-        id: upload-release-asset-amd64-zip-checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
-          asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-          asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
-          asset_content_type: text/plain
-      - name: Upload Release Asset new checksum
-        id: upload-release-asset-new-checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
-          asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
-          asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
-          asset_content_type: text/plain
-  chocolatey-publish:
-    name: Release Kaytu choco
-    if: github.event.inputs.publishChocolatey == 'true'
-    runs-on: windows-latest
-    needs:
-      - tag
-      - release
-      - sign-windows
-    steps:
-      - uses: actions/checkout@v2
-      - name: Generate & push
-        run: scripts/build.ps1
-        env:
-          CHOCO_API_KEY: ${{ secrets.CHOCO_APIKEY }}
+#       - name: Upload Release Asset amd64 zip
+#         id: upload-release-asset-amd64-zip
+#         uses: actions/upload-release-asset@v1
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+#         with:
+#           upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
+#           asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
+#           asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64.zip
+#           asset_content_type: application/zip
+#       - name: Upload Release Asset amd64 zip checksum
+#         id: upload-release-asset-amd64-zip-checksum
+#         uses: actions/upload-release-asset@v1
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+#         with:
+#           upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
+#           asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+#           asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_windows_amd64_checksum.txt
+#           asset_content_type: text/plain
+#       - name: Upload Release Asset new checksum
+#         id: upload-release-asset-new-checksum
+#         uses: actions/upload-release-asset@v1
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+#         with:
+#           upload_url: ${{ steps.add_windows_zip.outputs.upload_url }}
+#           asset_path: ./kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
+#           asset_name: kaytu_${{ steps.set_new_tag.outputs.new_tag }}_checksums.txt
+#           asset_content_type: text/plain
+#   chocolatey-publish:
+#     name: Release Kaytu choco
+#     if: github.event.inputs.publishChocolatey == 'true'
+#     runs-on: windows-latest
+#     needs:
+#       - release
+#       - sign-windows
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: Generate & push
+#         run: scripts/build.ps1
+#         env:
+#           CHOCO_API_KEY: ${{ secrets.CHOCO_APIKEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,7 @@ archives:
 
 
 brews:
-  -
-    name: kaytu-cli
+  - name: kaytu-cli
     homepage: https://github.com/adorigi/kaytu
     repository:
       owner: "{{ .Env.REPOSITORY_OWNER }}"
@@ -59,6 +58,10 @@ brews:
     commit_author:
       name:  "{{ .Env.REPOSITORY_OWNER }}"
       email: gulegulzaradnan@gmail.com
+    ids:
+      - binary
+      - default
+      - windows
 
 
 #chocolateys:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,12 @@ archives:
   - id: windows
     format: zip
     builds: [windows]
+  - id: linux
+    format: tar.gz
+    builds: [linux]
+  - id: darwin 
+    format: tar.gz
+    builds: [darwin]
 
 
 brews:
@@ -59,9 +65,8 @@ brews:
       name:  "{{ .Env.REPOSITORY_OWNER }}"
       email: gulegulzaradnan@gmail.com
     ids:
-      - binary
-      - default
-      - windows
+      - linux
+      - darwin
 
 
 #chocolateys:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
   - id: darwin
     binary: kaytu
     ldflags:
-      - -s -w -X github.com/"{{ .Env.REPOSITORY_OWNER }}"/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
+      - -s -w -X github.com/{{ .Env.REPOSITORY_OWNER }}/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
     goos:
       - darwin
     goarch:
@@ -32,7 +32,7 @@ builds:
   - id: windows
     binary: kaytu
     ldflags:
-      - -s -w -X github.com/"{{ .Env.REPOSITORY_OWNER }}"/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
+      - -s -w -X github.com/{{ .Env.REPOSITORY_OWNER }}/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
     goos:
       - windows
     goarch:
@@ -47,6 +47,20 @@ archives:
   - id: windows
     format: zip
     builds: [windows]
+
+
+brews:
+  -
+    name: kaytu-cli
+    homepage: https://github.com/adorigi/kaytu
+    repository:
+      owner: "{{ .Env.REPOSITORY_OWNER }}"
+      name: "{{ .Env.HOMEBREW_TAP }}" 
+    commit_author:
+      name:  "{{ .Env.REPOSITORY_OWNER }}"
+      email: gulegulzaradnan@gmail.com
+
+
 #chocolateys:
 #  - name: kaytu
 #    ids:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@ project_name: kaytu
 
 release:
   github:
-    owner: kaytu-io
-    name: kaytu
+    owner: "{{ .Env.REPOSITORY_OWNER }}"
+    name:  "{{ .Env.REPOSITORY_NAME }}"
 
 checksum: {}
 
@@ -12,7 +12,7 @@ builds:
   - id: linux
     binary: kaytu
     ldflags:
-      - -s -w -X github.com/kaytu-io/kaytu/pkg/version.VERSION={{ .Version }}
+      - -s -w -X github.com/{{ .Env.REPOSITORY_OWNER }}/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
     goos:
       - linux
     goarch:
@@ -22,7 +22,7 @@ builds:
   - id: darwin
     binary: kaytu
     ldflags:
-      - -s -w -X github.com/kaytu-io/kaytu/pkg/version.VERSION={{ .Version }}
+      - -s -w -X github.com/"{{ .Env.REPOSITORY_OWNER }}"/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
     goos:
       - darwin
     goarch:
@@ -32,7 +32,7 @@ builds:
   - id: windows
     binary: kaytu
     ldflags:
-      - -s -w -X github.com/kaytu-io/kaytu/pkg/version.VERSION={{ .Version }}
+      - -s -w -X github.com/"{{ .Env.REPOSITORY_OWNER }}"/{{ .Env.REPOSITORY_NAME }}/pkg/version.VERSION={{ .Version }}
     goos:
       - windows
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,7 @@ archives:
 
 
 brews:
-  - name: kaytu-cli
+  - name: kaytu
     homepage: https://github.com/adorigi/kaytu
     repository:
       owner: "{{ .Env.REPOSITORY_OWNER }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,9 +41,9 @@ builds:
 archives:
   - id: binary
     format: binary
-  - id: default
-    format: tar.gz
-    builds: [linux, darwin]
+  # - id: default
+  #   format: tar.gz
+  #   builds: [linux, darwin]
   - id: windows
     format: zip
     builds: [windows]


### PR DESCRIPTION
## Description
 - Modified the `tag` job to create the tags using the `github.ref_name`, which translates to the pushed tag during workflow run. 
- Removed the step which uses `mathieudutour/github-tag-action`, as we no longer are generating the tags at runtime. 
- The regex used for release tags that will trigger this job - `v[0-9]+.[0-9]+.[0-9]+`.  Example tag - `v1.2.3`. 
- The regex used for pre-release tags that will trigger this job - `v[0-9]+.[0-9]+.[0-9]+-rc`.  Example tag - `v1.2.3-rc`.
- We can completely remove the `tag` job in the future and use the `github.ref_name`, but keeping it for now as other jobs depend on it. 

## The new steps which will trigger the main workflow:
- push changes to the main branch(merge pull request) - no workflow run will be triggered
- create the tag locally - `git tag <new tag>` 
- push the tag - `git push origin --tags`
- the workflow run will be triggered

Tested the branch locally and can confirm that the `tag` job runs successfully. It has the same outputs as before.

## What type of PR(Pull Request) is this?
- [ ] 🐛 Bug Fix
- [ ] 🍕 New Feature
- [ ] 🔥 Performance Improvement
- [ ] 📝 Documentation update 
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Release
- [x] 🔁 CI/CD
## Added to documentation?
- [ ] 📜 README.md
- [ ] 🤝 CONTRIBUTING.md
- [x] 🙅 no documentation needed