### PR TITLE
Fixes bug where pre-releases are marked as latest releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,10 +12,10 @@ on:
                 default: "false"
 
 env:
-    REPOSITORY_OWNER: "kaytu-io"
+    REPOSITORY_OWNER: "adorigi"
     REPOSITORY_NAME: "kaytu"
-    HOMEBREW_TAP: "homebrew-cli-tap"
-    OWNER_EMAIL: "dev@kaytu.io"
+    HOMEBREW_TAP: "homebrew-adorigi"
+    OWNER_EMAIL: "gulegulzaradnan@gmail.com"
 
 jobs:
   tag:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,6 +91,7 @@ jobs:
           REPOSITORY_NAME: ${{ env.REPOSITORY_NAME }}
           OWNER_EMAIL: ${{ env.OWNER_EMAIL }}
           HOMEBREW_TAP: ${{ env.HOMEBREW_TAP }}
+          GORELEASER_MAKE_LATEST: "true"
 
   sign-windows:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,10 +12,10 @@ on:
                 default: "false"
 
 env:
-    REPOSITORY_OWNER: "adorigi"
+    REPOSITORY_OWNER: "kaytu-io"
     REPOSITORY_NAME: "kaytu"
-    HOMEBREW_TAP: "homebrew-adorigi"
-    OWNER_EMAIL: "gulegulzaradnan@gmail.com"
+    HOMEBREW_TAP: "homebrew-cli-tap"
+    OWNER_EMAIL: "dev@kaytu.io"
 
 jobs:
   tag:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -10,10 +10,10 @@ on:
       
 
 env:
-    REPOSITORY_OWNER: "adorigi"
+    REPOSITORY_OWNER: "kaytu-io"
     REPOSITORY_NAME: "kaytu"
-    HOMEBREW_TAP: "homebrew-adorigi"
-    OWNER_EMAIL: "gulegulzaradnan@gmail.com"
+    HOMEBREW_TAP: "homebrew-cli-tap"
+    OWNER_EMAIL: "dev@kaytu.io"
 
 jobs:
   tag:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -10,10 +10,10 @@ on:
       
 
 env:
-    REPOSITORY_OWNER: "kaytu-io"
+    REPOSITORY_OWNER: "adorigi"
     REPOSITORY_NAME: "kaytu"
-    HOMEBREW_TAP: "homebrew-cli-tap"
-    OWNER_EMAIL: "dev@kaytu.io"
+    HOMEBREW_TAP: "homebrew-adorigi"
+    OWNER_EMAIL: "gulegulzaradnan@gmail.com"
 
 jobs:
   tag:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -91,6 +91,7 @@ jobs:
           REPOSITORY_NAME: ${{ env.REPOSITORY_NAME }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           COSIGN_SECRET: ${{ secrets.COSIGN_SECRET }}
+          GORELEASER_MAKE_LATEST: "false"
 
 #      - uses: robinraju/release-downloader@v1.10
 #        id: download_release_amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ release:
   github:
     owner: "{{ .Env.REPOSITORY_OWNER }}"
     name:  "{{ .Env.REPOSITORY_NAME }}"
+  prerelease: auto
+  make_latest: "{{ .Env.GORELEASER_MAKE_LATEST}}"
 
 checksum: {}
 


### PR DESCRIPTION
## Description
fixes #182 

The goreleaser configuration allows specifying if the release being created is to be marked `latest`. It also smartly understands if the release is a `pre-release`, by looking at the tag. From what I understand from [here](https://goreleaser.com/customization/release/#github), it will look for `-rc` in the tag. Setting the `prerelease` configuration as `auto`, fits perfectly to our use case. 

Changes:
- Adding corresponding variables in the `Release` and `Pre-release` workflows.
- Configuring goreleaser to work with these variables.