### PR TITLE
Linux packaging and Release tests

### DIFF
--- a/.github/workflows/installation-test.yaml
+++ b/.github/workflows/installation-test.yaml
@@ -1,0 +1,57 @@
+name: Installation Tests
+
+on:
+    release:
+      types: [released]
+
+env:
+    HOMEBREW_TAP: "homebrew-adorigi"
+
+jobs:
+
+  Version-from-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.remove_tag.outputs.version }}
+    steps:
+      - name: Remove tag
+        id: remove_tag
+        run: |
+            TAG=${{ github.event.release.tag_name }}
+            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+  Deb-Package:
+    runs-on: ubuntu-latest
+    container: ubuntu:24.10
+    needs: 
+        - Version-from-tag
+    steps:
+      - name: Setup image
+        run: |
+            apt update
+            apt install wget -y
+      - name: Download Release
+        run: wget https://github.com/ADorigi/kaytu/releases/download/${{ github.event.release.tag_name }}/kaytu_${{ needs.Version-from-tag.outputs.version }}_linux_amd64.deb
+      - name: Install Kaytu
+        run: |
+            dpkg -i kaytu_${{ needs.Version-from-tag.outputs.version }}_linux_amd64.deb
+            kaytu
+      - name: Print Kaytu Version
+        run: kaytu version
+
+
+  Homebrew:
+    runs-on: macos-latest
+    if: always()
+    needs: 
+        - Version-from-tag
+    steps:
+      - name: Tap Kaytu's cli-tap
+        run: brew tap kaytu-io/cli-tap 
+      - name: Install Kaytu 
+        run: |
+            brew install kaytu
+            kaytu 
+      - name: Print Kaytu Version
+        run: kaytu version
+       

--- a/.github/workflows/installation-test.yaml
+++ b/.github/workflows/installation-test.yaml
@@ -5,6 +5,7 @@ on:
       types: [released]
 
 env:
+    REPOSITORY_OWNER: "adorigi"
     HOMEBREW_TAP: "homebrew-adorigi"
 
 jobs:
@@ -22,7 +23,7 @@ jobs:
 
   Deb-Package:
     runs-on: ubuntu-latest
-    container: ubuntu:24.10
+    container: debian
     needs: 
         - Version-from-tag
     steps:
@@ -39,15 +40,33 @@ jobs:
       - name: Print Kaytu Version
         run: kaytu version
 
+  RPM-Package:
+    runs-on: ubuntu-latest
+    container: redhat/ubi8:latest
+    needs: 
+        - Version-from-tag
+        - Deb-Package
+    steps:
+      - name: Setup image
+        run: |
+            yum install wget -y
+      - name: Download Release
+        run: wget https://github.com/ADorigi/kaytu/releases/download/${{ github.event.release.tag_name }}/kaytu_${{ needs.Version-from-tag.outputs.version }}_linux_amd64.rpm
+      - name: Install Kaytu
+        run: |
+            rpm -i kaytu_${{ needs.Version-from-tag.outputs.version }}_linux_amd64.rpm
+            kaytu
+      - name: Print Kaytu Version
+        run: kaytu version
 
   Homebrew:
     runs-on: macos-latest
     if: always()
     needs: 
-        - Version-from-tag
+        - RPM-Package
     steps:
       - name: Tap Kaytu's cli-tap
-        run: brew tap kaytu-io/cli-tap 
+        run: brew tap ${{ env.REPOSITORY_OWNER }}/${{ env.HOMEBREW_TAP }}
       - name: Install Kaytu 
         run: |
             brew install kaytu

--- a/.github/workflows/installation-test.yaml
+++ b/.github/workflows/installation-test.yaml
@@ -5,8 +5,8 @@ on:
       types: [released]
 
 env:
-    REPOSITORY_OWNER: "adorigi"
-    HOMEBREW_TAP: "homebrew-adorigi"
+    REPOSITORY_OWNER: "kaytu-io"
+    HOMEBREW_TAP: "cli-tap"
 
 jobs:
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,10 +12,10 @@ on:
                 default: "false"
 
 env:
-    REPOSITORY_OWNER: "kaytu-io"
+    REPOSITORY_OWNER: "adorigi"
     REPOSITORY_NAME: "kaytu"
-    HOMEBREW_TAP: "homebrew-cli-tap"
-    OWNER_EMAIL: "dev@kaytu.io"
+    HOMEBREW_TAP: "homebrew-adorigi"
+    OWNER_EMAIL: "gulegulzaradnan@gmail.com"
 
 jobs:
   tag:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,10 +12,10 @@ on:
                 default: "false"
 
 env:
-    REPOSITORY_OWNER: "adorigi"
+    REPOSITORY_OWNER: "kaytu-io"
     REPOSITORY_NAME: "kaytu"
-    HOMEBREW_TAP: "homebrew-adorigi"
-    OWNER_EMAIL: "gulegulzaradnan@gmail.com"
+    HOMEBREW_TAP: "homebrew-cli-tap"
+    OWNER_EMAIL: "dev@kaytu.io"
 
 jobs:
   tag:
@@ -34,7 +34,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          release_branches: linux-packaging
+          release_branches: main
           tag_prefix: v
       - name: Set latest tag output
         id: set_latest_tag

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          release_branches: main
+          release_branches: linux-packaging
           tag_prefix: v
       - name: Set latest tag output
         id: set_latest_tag

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,6 +73,15 @@ brews:
       - linux
       - darwin
 
+nfpms:
+  - package_name: "{{ .ProjectName }}"
+    maintainer: "{{ .Env.REPOSITORY_OWNER }} <{{ .Env.OWNER_EMAIL }}>"
+    homepage: https://github.com/{{ .Env.REPOSITORY_OWNER }}/{{ .Env.REPOSITORY_NAME }}
+    builds:
+      - linux
+    formats:
+      - deb
+      - rpm
 
 #chocolateys:
 #  - name: kaytu

--- a/scripts/install_deb_amd64.sh
+++ b/scripts/install_deb_amd64.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 apt update
-apt install -y wget curl
+apt install -y wget curl jq
 
 DEB_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
-| grep "browser_download_url.*amd64.deb" \
-| cut -d : -f 2,3 \
-| tr -d \" )
+| jq -r '.assets[] | select(.name | endswith("amd64.deb")).browser_download_url')
 
 echo $DEB_FILE_URL
 

--- a/scripts/install_deb_amd64.sh
+++ b/scripts/install_deb_amd64.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+apt update
+apt install -y wget curl
+
+DEB_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+| grep "browser_download_url.*amd64.deb" \
+| cut -d : -f 2,3 \
+| tr -d \" )
+
+echo $DEB_FILE_URL
+
+wget -q $DEB_FILE_URL
+
+FILENAME=$(basename "$DEB_FILE_URL")
+
+apt install ./$FILENAME
+

--- a/scripts/install_deb_amd64.sh
+++ b/scripts/install_deb_amd64.sh
@@ -3,7 +3,7 @@
 apt update
 apt install -y wget curl
 
-DEB_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+DEB_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
 | grep "browser_download_url.*amd64.deb" \
 | cut -d : -f 2,3 \
 | tr -d \" )

--- a/scripts/install_deb_arm64.sh
+++ b/scripts/install_deb_arm64.sh
@@ -3,7 +3,7 @@
 apt update
 apt install -y wget curl
 
-DEB_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+DEB_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
 | grep "browser_download_url.*arm64.deb" \
 | cut -d : -f 2,3 \
 | tr -d \" )

--- a/scripts/install_deb_arm64.sh
+++ b/scripts/install_deb_arm64.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 apt update
-apt install -y wget curl
+apt install -y wget curl jq
 
 DEB_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
-| grep "browser_download_url.*arm64.deb" \
-| cut -d : -f 2,3 \
-| tr -d \" )
+| jq -r '.assets[] | select(.name | endswith("arm64.deb")).browser_download_url')
 
 echo $DEB_FILE_URL
 

--- a/scripts/install_deb_arm64.sh
+++ b/scripts/install_deb_arm64.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+apt update
+apt install -y wget curl
+
+DEB_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+| grep "browser_download_url.*arm64.deb" \
+| cut -d : -f 2,3 \
+| tr -d \" )
+
+echo $DEB_FILE_URL
+
+wget -q $DEB_FILE_URL
+
+FILENAME=$(basename "$DEB_FILE_URL")
+
+apt install ./$FILENAME
+

--- a/scripts/install_rpm_amd64.sh
+++ b/scripts/install_rpm_amd64.sh
@@ -3,9 +3,7 @@
 yum install -y wget curl
 
 RPM_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
-| grep "browser_download_url.*amd64.rpm" \
-| cut -d : -f 2,3 \
-| tr -d \" )
+| jq -r '.assets[] | select(.name | endswith("amd64.rpm")).browser_download_url')
 
 echo $RPM_FILE_URL
 

--- a/scripts/install_rpm_amd64.sh
+++ b/scripts/install_rpm_amd64.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+yum install -y wget curl
+
+RPM_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+| grep "browser_download_url.*amd64.rpm" \
+| cut -d : -f 2,3 \
+| tr -d \" )
+
+echo $RPM_FILE_URL
+
+wget -q $RPM_FILE_URL
+
+FILENAME=$(basename "$RPM_FILE_URL")
+
+yum install -y $FILENAME

--- a/scripts/install_rpm_amd64.sh
+++ b/scripts/install_rpm_amd64.sh
@@ -2,7 +2,7 @@
 
 yum install -y wget curl
 
-RPM_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+RPM_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
 | grep "browser_download_url.*amd64.rpm" \
 | cut -d : -f 2,3 \
 | tr -d \" )

--- a/scripts/install_rpm_arm64.sh
+++ b/scripts/install_rpm_arm64.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-yum install -y wget curl
+yum install -y wget curl jq
 
 RPM_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
-| grep "browser_download_url.*arm64.rpm" \
-| cut -d : -f 2,3 \
-| tr -d \" )
+| jq -r '.assets[] | select(.name | endswith("arm64.rpm")).browser_download_url')
 
 echo $RPM_FILE_URL
 

--- a/scripts/install_rpm_arm64.sh
+++ b/scripts/install_rpm_arm64.sh
@@ -2,7 +2,7 @@
 
 yum install -y wget curl
 
-RPM_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+RPM_FILE_URL=$(curl -s https://api.github.com/repos/kaytu-io/kaytu/releases/latest \
 | grep "browser_download_url.*arm64.rpm" \
 | cut -d : -f 2,3 \
 | tr -d \" )

--- a/scripts/install_rpm_arm64.sh
+++ b/scripts/install_rpm_arm64.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+yum install -y wget curl
+
+RPM_FILE_URL=$(curl -s https://api.github.com/repos/adorigi/kaytu/releases/latest \
+| grep "browser_download_url.*arm64.rpm" \
+| cut -d : -f 2,3 \
+| tr -d \" )
+
+echo $RPM_FILE_URL
+
+wget -q $RPM_FILE_URL
+
+FILENAME=$(basename "$RPM_FILE_URL")
+
+yum install -y $FILENAME


### PR DESCRIPTION
fixes #196 
Adds `RPM` and `DEB` for `amd64` and `arm64` architectures.

fixes #195 
Original plan was to modify release workflow. To not break what is working, decided to not touch the main workflow. Instead, added a new workflow which tests the artifacts on `Release`. 